### PR TITLE
fix trip engine for hybrid cars + locale + get_vehicles url

### DIFF
--- a/trip_parser.py
+++ b/trip_parser.py
@@ -32,7 +32,10 @@ class TripParser:
     def get_hybrid_consumption(start, end):
         res = []
         for energy in [LEVEL, LEVEL_FUEL]:
-            res.append(start[energy] - end[energy])
+            if start[energy] is not None and end[energy] is not None:
+                res.append(start[energy] - end[energy])
+            else:
+                res.append(0)
         return res
 
     def __is_refuel_or_recharging(self, start, end, distance):

--- a/web/app.py
+++ b/web/app.py
@@ -25,7 +25,7 @@ def start_app(title, base_path, debug: bool, host, port):
         lang = locale.getlocale()[0].split("_")[0]
         locale.setlocale(locale.LC_TIME, ".".join(locale.getlocale())) #make sure LC_TIME is set
         locale_url = [f"https://cdn.plot.ly/plotly-locale-{lang}-latest.js"]
-    except IndexError:
+    except (IndexError, locale.Error):
         locale_url = None
         logger.warning("Can't get language")
     app = Flask(__name__)

--- a/web/views.py
+++ b/web/views.py
@@ -48,9 +48,14 @@ def display_value(value):
            figures.battery_table, max_millis, step, marks
 
 
-@app.route('/getvehicles')
+@app.route('/get_vehicles')
 def get_vehicules():
-    return jsonify(myp.get_vehicles())
+    response = app.response_class(
+        response=json.dumps(myp.get_vehicles(), default=lambda car: car.to_dict()),
+        status=200,
+        mimetype='application/json'
+    )
+    return response
 
 
 @app.route('/get_vehicleinfo/<string:vin>')


### PR DESCRIPTION
Hello
After this PR, we could simplify TripParser class and use only get_hybrid_consumption (we could as well renamed it as get_consumption).
This function can now work for all types of cars. I had to add the 'if xxx is not None' sequence because for fuel and hybrid cars, the API doesnt provide the fuel level when car is off and I don't want to have wrong values in database.