### PR TITLE
Prevent division by zero during calculation of co2_per_kw

### DIFF
--- a/web/figures.py
+++ b/web/figures.py
@@ -111,11 +111,7 @@ def get_figures(trips: Trips, charging: Tuple[dict]):
 
     # charging
     charging_data = DataFrame.from_records(charging)
-    try:
-        co2_data = charging_data[charging_data["co2"] > 0]
-        co2_per_kw = co2_data["co2"].sum() / co2_data["kw"].sum()
-    except (ZeroDivisionError, KeyError):
-        co2_per_kw = 0
+    co2_per_kw = __calculate_co2_per_kw(charging_data)
     co2_per_km = co2_per_kw * kw_per_km / 100
     try:
         charge_speed = 3600 * charging_data["kw"].mean() / \
@@ -181,3 +177,13 @@ def get_figures(trips: Trips, charging: Tuple[dict]):
 
     else:
         consumption_graph_by_temp = Graph(style={'display': 'none'})
+
+
+def __calculate_co2_per_kw(charging_data):
+    try:
+        co2_data = charging_data[charging_data["co2"] > 0]
+        if co2_data["kw"].sum() > 0:
+            return co2_data["co2"].sum() / co2_data["kw"].sum()
+    except KeyError:
+        return 0
+    return 0

--- a/web/figures.py
+++ b/web/figures.py
@@ -182,8 +182,9 @@ def get_figures(trips: Trips, charging: Tuple[dict]):
 def __calculate_co2_per_kw(charging_data):
     try:
         co2_data = charging_data[charging_data["co2"] > 0]
-        if co2_data["kw"].sum() > 0:
-            return co2_data["co2"].sum() / co2_data["kw"].sum()
+        co2_kw_sum = co2_data["kw"].sum()
+        if co2_kw_sum > 0:
+            return co2_data["co2"].sum() / co2_kw_sum
     except KeyError:
         return 0
     return 0


### PR DESCRIPTION
possible solution for preventing the warning mentioned in #67 