### PR TITLE
store charge controls file name in ChargeControls to save it without …

### DIFF
--- a/ChargeControl.py
+++ b/ChargeControl.py
@@ -104,11 +104,12 @@ class ChargeControl:
 
 class ChargeControls(dict):
 
-    def __init__(self):
+    def __init__(self, file_name="charge_config.json"):
+        self.file_name = file_name
         super().__init__()
         self._config_hash = None
 
-    def save_config(self, name="charge_config.json", force=False):
+    def save_config(self, force=False):
         chd = {}
         charge_control: ChargeControl
         for charge_control in self.values():
@@ -117,7 +118,7 @@ class ChargeControls(dict):
         config_str = json.dumps(chd, sort_keys=True, indent=4).encode('utf-8')
         new_hash = md5(config_str).hexdigest()
         if force or self._config_hash != new_hash:
-            with open(name, "wb") as f:
+            with open(self.file_name, "wb") as f:
                 f.write(config_str)
             self._config_hash = new_hash
             logger.info("save config change")
@@ -127,7 +128,7 @@ class ChargeControls(dict):
         with open(name, "r") as f:
             config_str = f.read()
             chd = json.loads(config_str)
-            charge_control_list = ChargeControls()
+            charge_control_list = ChargeControls(name)
             for vin, el in chd.items():
                 charge_control_list[vin] = ChargeControl(psacc, vin, **el)
             return charge_control_list

--- a/app_decoder.py
+++ b/app_decoder.py
@@ -158,10 +158,10 @@ psacc.vehicles_list.save_cars()
 print(f"\nYour vehicles: {res}")
 
 # Charge control
-charge_controls = ChargeControls()
+charge_controls = ChargeControls("charge_config1.json")
 for vehicle in res:
     chc = ChargeControl(psacc, vehicle.vin, 100, [0, 0])
     charge_controls[vehicle.vin] = chc
-charge_controls.save_config(name="charge_config1.json")
+charge_controls.save_config()
 
 print("Success !!!")


### PR DESCRIPTION
This stores the file name property inside the ChargeConfigs and uses it when saving the config.
This solves the problem of loading the config for the specified filename but saving it for the default name