### PR TITLE
Don't display password when entered / show correct app name in server

### DIFF
--- a/MyPSACC.py
+++ b/MyPSACC.py
@@ -31,11 +31,13 @@ from geojson import dumps as geo_dumps
 PSA_CORRELATION_DATE_FORMAT = "%Y%m%d%H%M%S%f"
 PSA_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-oauhth_url = {"clientsB2CPeugeot": "https://idpcvs.peugeot.com/am/oauth2/access_token",
-              "clientsB2CCitroen": "https://idpcvs.citroen.com/am/oauth2/access_token",
-              "clientsB2CDS": "https://idpcvs.driveds.com/am/oauth2/access_token",
-              "clientsB2COpel": "https://idpcvs.opel.com/am/oauth2/access_token",
-              "clientsB2CVauxhall": "https://idpcvs.vauxhall.co.uk/am/oauth2/access_token"}
+realm_info = {
+    "clientsB2CPeugeot": {"oauth_url": "https://idpcvs.peugeot.com/am/oauth2/access_token", "app_name": "MyPeugeot"},
+    "clientsB2CCitroen": {"oauth_url": "https://idpcvs.citroen.com/am/oauth2/access_token", "app_name": "MyCitroen"},
+    "clientsB2CDS": {"oauth_url": "https://idpcvs.driveds.com/am/oauth2/access_token", "app_name": "MyDS"},
+    "clientsB2COpel": {"oauth_url": "https://idpcvs.opel.com/am/oauth2/access_token", "app_name": "MyOpel"},
+    "clientsB2CVauxhall": {"oauth_url": "https://idpcvs.vauxhall.co.uk/am/oauth2/access_token", "app_name": "MyVauxhall"}
+}
 
 authorize_service = "https://api.mpsa.com/api/connectedcar/v2/oauth/authorize"
 remote_url = "https://api.groupe-psa.com/connectedcar/v4/virtualkey/remoteaccess/token?client_id="
@@ -135,7 +137,7 @@ class MyPSACC:
                  proxies=None, weather_api=None):
         self.realm = realm
         self.service_information = ServiceInformation(authorize_service,
-                                                      oauhth_url[self.realm],
+                                                      realm_info[self.realm]['oauth_url'],
                                                       client_id,
                                                       client_secret,
                                                       scopes, False)
@@ -167,6 +169,9 @@ class MyPSACC:
         self.precond_programs = {}
         self.info_callback = []
         self.info_refresh_rate = 120
+
+    def get_app_name(self):
+        return realm_info[self.realm]['app_name']
 
     def refresh_token(self):
         self.manager._refresh_token()

--- a/app_decoder.py
+++ b/app_decoder.py
@@ -10,6 +10,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.hazmat.backends import default_backend
 
+from getpass import getpass
+
 from ChargeControl import ChargeControl, ChargeControls
 from MyPSACC import MyPSACC
 from sys import argv
@@ -20,7 +22,7 @@ BRAND = {"com.psa.mym.myopel": {"realm": "clientsB2COpel", "brand_code": "OP", "
          "com.psa.mym.mypeugeot": {"realm": "clientsB2CPeugeot", "brand_code": "AP", "app_name": "MyPeugeot"},
          "com.psa.mym.mycitroen": {"realm": "clientsB2CCitroen", "brand_code": "AC", "app_name": "MyCitroen"},
          "com.psa.mym.myds": {"realm": "clientsB2CDS", "brand_code": "AC", "app_name": "MyDS"},
-         "com.psa.mym.myvauxhall": {"realm": "clientsB2CVauxhall", "brand_code": "0V", "app_name": "MyVauxall"}
+         "com.psa.mym.myvauxhall": {"realm": "clientsB2CVauxhall", "brand_code": "0V", "app_name": "MyVauxhall"}
          }
 
 
@@ -87,7 +89,7 @@ remote_refresh_token = None
 print("APK loaded !")
 
 client_email = input(f"{BRAND[package_name]['app_name']} email: ")
-client_password = input(f"{BRAND[package_name]['app_name']} password: ")
+client_password = getpass(f"{BRAND[package_name]['app_name']} password: ")
 
 country_code = input("What is your country code ? (ex: FR, GB, DE, ES...)\n")
 

--- a/server.py
+++ b/server.py
@@ -6,6 +6,8 @@ from threading import Thread
 
 from oauth2_client.credentials_manager import OAuthError
 
+from getpass import getpass
+
 import web.app
 from ChargeControl import ChargeControls
 from MyLogger import my_logger
@@ -65,8 +67,8 @@ if __name__ == "__main__":
                 client_email = args.mail
                 client_password = args.password
             else:
-                client_email = input("mypeugeot email: ")
-                client_password = input("mypeugeot password: ")
+                client_email = input(f"{web.app.myp.get_app_name()} email: ")
+                client_password = getpass(f"{web.app.myp.get_app_name()} password: ")
             web.app.myp.connect(client_email, client_password)
         logger.info(str(web.app.myp.get_vehicles()))
         if args.remote_disable:


### PR DESCRIPTION
The getpass function does not display the password when entered like other password prompts on e.g. a raspberry pi or ubuntu machine.

Additionally the server displays the correct app name when asking for email/password just like app_decoded already does and I found a little typo in the Vauxhall app name

