### PR TITLE
Add -r parameter to Docker image's server.py call

### DIFF
--- a/docker_files/init.sh
+++ b/docker_files/init.sh
@@ -20,5 +20,5 @@ then
     /bin/bash
 else
     echo "SHELL_ONLY = FALSE. Running server.py"
-    python3 /psa_car_controller/server.py -f /config/test.json -c /config/charge_config1.json -p 5000 -l 0.0.0.0
+    python3 /psa_car_controller/server.py -f /config/test.json -c /config/charge_config1.json -p 5000 -l 0.0.0.0 -r
 fi


### PR DESCRIPTION
In response to issue [114](https://github.com/flobz/psa_car_controller/issues/114#issue-883959429), I have added the '-r' parameter in the Docker image's init.sh server.py call to enable the web dashboard.  