### PR TITLE
Delayed start of the server in the Docker container

### DIFF
--- a/docker_files/init.sh
+++ b/docker_files/init.sh
@@ -2,4 +2,5 @@
 echo "Containerised psa_car_controller loading..."
 cd "$PSACC_CONFIG_DIR"
 ARGS="-p $PSACC_PORT -l 0.0.0.0 -b $PSACC_BASE_PATH $PSACC_OPTIONS"
+sleep 30
 python3 -u /psa_car_controller/server.py $ARGS


### PR DESCRIPTION
In some cases the Docker container does not seem to have started properly before the python server starts. This results in the configuration being overwritten.
See https://github.com/flobz/psa_car_controller/issues/236