### PR TITLE
Adding Citroen C3 Model 2021

### DIFF
--- a/libs/car_model.py
+++ b/libs/car_model.py
@@ -69,6 +69,7 @@ car_models = [
     CarModel("SUV 5008 II", 0, 56, reg=r"VF3MRHNS.*"),  # vf3mrhnsum
     CarModel("SUV 5008 II 2018", 0, 56, reg=r"VF3MRHNY.*"),  # VF3MRHNYHH
     CarModel("N5008 GT-LINE 1.6L", 0, 60, reg=r"VF3MCBHZ.*"),  # VF3MCBHZWJ
+    CarModel("C3", 0, 42, reg=r"VF7SXHNP.*"),  # VF7SXHNPYL Model 2021
     CarModel("C5 Aircross Hybrid", 13.2, 43, reg=r"VR7A4DGZ.*"),  # VR7A4DGZSM
     CarModel("DS7 Crossback E-Tense 300 4x4", 11.5, 43, reg="VR1J45GB.*"),  # VR1J45GBUM VR1J45GBUL VR1J45GBUK
     CarModel("508 SW Hybrid", 11.5, 45, reg=r"VR3F4DGZ.*"),  # VR3F4DGZTL


### PR DESCRIPTION
Hello there,

Please have here my small addition to this project.
Citroen C3 - Model 2021 - Not an electric car, only gasoline.
[Citroen C3](https://media.citroen.be/image/84/6/offre_c3_showroom_fr.368846.png)

Thanks,