### PR TITLE
Add restart policy to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "2"
 services:
   psacc:
     image: flobz/psa_car_controller:latest
+    restart: unless-stopped
     ports:
       - "5000:5000"
     volumes:


### PR DESCRIPTION
For the normal docker start command you use that restart policy, the docker-compose do not have it, but makes sense I think