### PR TITLE
Removed redudant [SE] block

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -97,7 +97,7 @@
   battery_power: 0
   fuel_capacity: 44
   abrp_name:
-  reg: VR3UPHN.*
+  reg: VR3UPHN[SEK].*
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !CarModel

--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -97,7 +97,7 @@
   battery_power: 0
   fuel_capacity: 44
   abrp_name:
-  reg: VR3UPHN[SE].*
+  reg: VR3UPHN.*
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !CarModel


### PR DESCRIPTION
Not sure if the [SE] block in the reg was added on purpose, it may cause an error in my setup where the vehicle is not found while setting up the PSA Car Controller.