### PR TITLE
Remove old link for a deprecated video

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ With this app  you will be able to :
 
 The official api is documented [here](https://developer.groupe-psa.io/webapi/b2c/quickstart/connect/#article) but it is not totally up to date, and contains some errors. 
 
-A video in French was made by vlycop to explain how to use this application : https://youtu.be/XO7-N7G3biU 
-
 
  ## I. Installation
 - [Installation on Linux or Windows](docs/Install.md)


### PR DESCRIPTION
Hello :)

I have been informed that my video is nolonger relevant. many thing have changed for the better :D

I will remove it from youtube and think you should remove it first to avoid a broken link.

Thank you for the good work !