### PR TITLE
Fix some charge control issues

### DIFF
--- a/psa_car_controller/psa/RemoteClient.py
+++ b/psa_car_controller/psa/RemoteClient.py
@@ -89,7 +89,7 @@ class RemoteClient:
             logger.exception("on_mqtt_message:")
 
     def _fix_not_updated_api(self, charge_info, vin):
-        if charge_info is not None and charge_info.get('remaining_time', 0) != 0 and charge_info.get('rate', 0) != 0:
+        if charge_info is not None and (charge_info.get('remaining_time', 0) != 0 or charge_info.get('rate', 0) != 0):
             try:
                 car = self.vehicles_list.get_car_by_vin(vin=vin)
                 if car and car.status.get_energy('Electric').charging.status != INPROGRESS:

--- a/psa_car_controller/psa/RemoteClient.py
+++ b/psa_car_controller/psa/RemoteClient.py
@@ -92,6 +92,10 @@ class RemoteClient:
         if charge_info is not None and charge_info.get('remaining_time', 0) != 0:
             try:
                 car = self.vehicles_list.get_car_by_vin(vin=vin)
+                if car and car.status.get_energy('Electric').charging.status == INPROGRESS and charge_info.get('rate', 0) != 0:
+                    # if the api report the car as charging and the charging rate is not 0, it means that the api is up to date
+                    return
+
                 if car and car.status.get_energy('Electric').charging.status != INPROGRESS:
                     # fix a psa server bug where charge beginning without status api being properly updated
                     logger.warning("charge begin but API isn't updated")

--- a/psa_car_controller/psa/RemoteClient.py
+++ b/psa_car_controller/psa/RemoteClient.py
@@ -89,13 +89,9 @@ class RemoteClient:
             logger.exception("on_mqtt_message:")
 
     def _fix_not_updated_api(self, charge_info, vin):
-        if charge_info is not None and charge_info.get('remaining_time', 0) != 0:
+        if charge_info is not None and charge_info.get('remaining_time', 0) != 0 and charge_info.get('rate', 0) != 0:
             try:
                 car = self.vehicles_list.get_car_by_vin(vin=vin)
-                if car and car.status.get_energy('Electric').charging.status == INPROGRESS and charge_info.get('rate', 0) != 0:
-                    # if the api report the car as charging and the charging rate is not 0, it means that the api is up to date
-                    return
-
                 if car and car.status.get_energy('Electric').charging.status != INPROGRESS:
                     # fix a psa server bug where charge beginning without status api being properly updated
                     logger.warning("charge begin but API isn't updated")

--- a/psa_car_controller/psacc/application/charging.py
+++ b/psa_car_controller/psacc/application/charging.py
@@ -83,7 +83,7 @@ class Charging:
             try:
                 last_charge = Database.get_last_charge(car.vin)
                 charge_just_finished = last_charge.stop_at is None
-            except TypeError:
+            except (TypeError, AttributeError):
                 logger.debug("battery table is probably empty :", exc_info=True)
                 charge_just_finished = False
             if charge_just_finished:


### PR DESCRIPTION
This PR fixes #385 and a bug where the app think the charging status from the PSA API is not up to date.

I got an issue with the received status MQTT message, where the charging state `remaining_time` field was never `0` even when the car was not plugged in, so I kept getting the message `charge begin but API isn't updated` even when the API was well updated.
I've added another check with the charging rate, which was correct in the MQTT message in my case to fix this issue.