### PR TITLE
add Peugeot 308 III Hybrid

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -227,6 +227,14 @@
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !CarModel
+  name: 308 Hybrid
+  battery_power: 12.4
+  fuel_capacity: 40
+  abrp_name:
+  reg: VR3F3DGYTN.*
+  max_elec_consumption: 70
+  max_fuel_consumption: 30
+- !CarModel
   name: 308 SW Hybrid
   battery_power: 12.4
   fuel_capacity: 40

--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -231,7 +231,7 @@
   battery_power: 12.4
   fuel_capacity: 40
   abrp_name:
-  reg: VR3F3DGYTN.*
+  reg: VR3F3DGYT.*
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !CarModel


### PR DESCRIPTION
based on https://www.mittns.de/core/lexicon/entry/9-peugeot-fahrzeug-identifizierungsnummer-fin-vin/ I removed also the 10th key because this indicates only the Year of production

fyi: should be done on other peugeot-cars too :D  (example https://github.com/flobz/psa_car_controller/pull/377/files)