### PR TITLE
Update charge_control.py

### DIFF
--- a/psa_car_controller/psacc/application/charge_control.py
+++ b/psa_car_controller/psacc/application/charge_control.py
@@ -88,7 +88,7 @@ class ChargeControl:
             if status == INPROGRESS:
                 logger.info("charging status of %s is %s, battery level: %d", self.vin, status, level)
                 self.force_update(vehicle_status)
-                if hit_threshold and self.retry_count < 2:
+                if has_threshold and hit_threshold and self.retry_count < 2:
                     logger.info("Charge threshold is reached, stop the charge")
                     self.control_charge_with_ack(False)
                 elif self._next_stop_hour is not None:


### PR DESCRIPTION
You need to avoid a charge stop when the level is 100 and percentage_threshold is 100 (so check has_threshold is true). This because sometimes our car is charging more kWh also if the level reported is 100%