### PR TITLE
Added DS4 E-Tense + fixed typo

### DIFF
--- a/psa_car_controller/psa/connected_car_api/models/position_properties.py
+++ b/psa_car_controller/psa/connected_car_api/models/position_properties.py
@@ -126,7 +126,7 @@ class PositionProperties(object):
         :param type: The type of this PositionProperties.  # noqa: E501
         :type: str
         """
-        allowed_values = ["Estimated", "Acquired", "Estimate", "Aquire"]  # noqa: E501
+        allowed_values = ["Estimated", "Acquired", "Estimate", "Acquire"]  # noqa: E501
         if type not in allowed_values:
             raise ValueError(
                 "Invalid value for `type` ({0}), must be one of {1}"  # noqa: E501

--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -312,3 +312,11 @@
   reg: VR3F4DGXTN.*
   max_elec_consumption: 70
   max_fuel_consumption: 30
+- !CarModel
+  name: DS4 E-Tense
+  battery_power: 12.4
+  fuel_capacity: 40
+  abrp_name:
+  reg: VR1F4DGYTM.*
+  max_elec_consumption: 70
+  max_fuel_consumption: 30


### PR DESCRIPTION
Error occurred in position_properties.py because of a typo: Aquire should be Acquire.