### PR TITLE
Remove model year character for DS4 E-Tense

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -324,7 +324,7 @@
   battery_power: 12.4
   fuel_capacity: 40
   abrp_name:
-  reg: VR1F4DGYTM.*
+  reg: VR1F4DGYT.*
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !CarModel


### PR DESCRIPTION
My VIN for the DS4 E-Tense is VR1F4DGYTP instead of VR1F4DGYTM in car_models.yml.
Removed the 10th character as it only corresponds to the model year.