### PR TITLE
[FIX] Upgrade version IPython for unittest VSCode windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ numpy = [{version = ">=1.24.0", python = ">=3.11"},
 scipy = [{version = ">=1.9.2", python = ">=3.11"},
          {version = "<1.11.0", python = "<3.8"},
          {version = "<1.8.0", python = "<3.8"}]
+ipython = "^7.0.0"
 
 [tool.poetry.dev-dependencies]
 prospector = "1.10.3"


### PR DESCRIPTION
- Python 3.9.2 
The lib IPython is loaded in version 5 but an issue is raised when test_unit.py wants to be loaded:
```
2023-11-12 22:09:13.189 [error] Error discovering unittest tests:
 Failed to import test module: test_unit
Traceback (most recent call last):
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\utils\timing.py", line 27, in <module>
    import resource
ModuleNotFoundError: No module named 'resource'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "...xxxxx....\AppData\Local\Programs\Python\Python39\lib\unittest\loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "...xxxxx....\AppData\Local\Programs\Python\Python39\lib\unittest\loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "...xxxxx....\psa_car_controller-3.9\tests\test_unit.py", line 36, in <module>
    from psa_car_controller.web.figures import get_figures, get_battery_curve_fig, get_altitude_fig
  File "...xxxxx....\psa_car_controller-3.9\psa_car_controller\web\__init__.py", line 1, in <module>
    from . import app
  File "...xxxxx....\psa_car_controller-3.9\psa_car_controller\web\app.py", line 5, in <module>
    import dash_bootstrap_components as dbc
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\dash_bootstrap_components\__init__.py", line 4, in <module>
    from dash_bootstrap_components import _components, icons, themes
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\dash_bootstrap_components\_components\__init__.py", line 1, in <module>
    from .Accordion import Accordion
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\dash_bootstrap_components\_components\Accordion.py", line 3, in <module>
    from dash.development.base_component import Component, _explicitize_args
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\dash\__init__.py", line 36, in <module>
    from .dash import (  # noqa: F401,E402
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\dash\dash.py", line 77, in <module>
    from ._jupyter import jupyter_dash, JupyterDisplayMode
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\dash\_jupyter.py", line 20, in <module>
    from IPython import get_ipython
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\__init__.py", line 49, in <module>
    from .terminal.embed import embed
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\terminal\embed.py", line 19, in <module>
    from IPython.terminal.ipapp import load_default_config
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\terminal\ipapp.py", line 30, in <module>
    from IPython.core.magics import ScriptMagics
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\core\magics\__init__.py", line 21, in <module>
    from .execution import ExecutionMagics
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\core\magics\execution.py", line 46, in <module>
    from IPython.utils.timing import clock, clock2
  File "...xxxxx....\psa_car_controller-3.9\.venv\lib\site-packages\IPython\utils\timing.py", line 64, in <module>
    clocku = clocks = clock = time.clock
AttributeError: module 'time' has no attribute 'clock'
```

The version IPython 8 is not compliant.
I hope to force version 7 will not have side effects