### PR TITLE
feat: make preconditioning failure available (in API)

### DIFF
--- a/psa_car_controller/psa/connected_car_api/models/preconditioning_air_conditioning.py
+++ b/psa_car_controller/psa/connected_car_api/models/preconditioning_air_conditioning.py
@@ -31,18 +31,20 @@ class PreconditioningAirConditioning(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'failure_cause': 'str',
         'status': 'str',
         'updated_at': 'datetime',
         'created_at': 'datetime'
     }
 
     attribute_map = {
+        'failure_cause': 'failureCause',
         'status': 'status',
         'updated_at': 'updatedAt',
         'created_at': 'createdAt',
     }
 
-    def __init__(self, status=None, updated_at=None, created_at=None):  # noqa: E501
+    def __init__(self, failure_cause=None, status=None, updated_at=None, created_at=None):  # noqa: E501
         """PreconditioningAirConditioning - a model defined in Swagger"""  # noqa: E501
 
         self._failure_cause = None
@@ -51,6 +53,8 @@ class PreconditioningAirConditioning(object):
         self._updated_at = None
         self.discriminator = None
 
+        if failure_cause is not None:
+            self.failure_cause = failure_cause
         if status is not None:
             self.status = status
         if updated_at is not None:


### PR DESCRIPTION
The preconditioning element has an interesting field called "failureCause" which reports error conditions like opened doors, battery low state etc preventing the preconditioning to run. These errors are interesting, so make them available in our API.

This field was removed in 619cefd4, not sure why, so add it again.

Fixes #760.