### PR TITLE
fix: missing step 1 in config_connect()

### DIFF
--- a/psa_car_controller/web/view/views.py
+++ b/psa_car_controller/web/view/views.py
@@ -77,7 +77,7 @@ def display_page(pathname, search):
     elif pathname == "/config_login":
         page = config_layout("login")
     elif pathname == "/config_connect":
-        page = get_oauth_config_layout(query_params["url"])
+        page = get_oauth_config_layout(query_params["url"][0])
     elif pathname == "/log":
         page = log_layout()
     elif not APP.is_good:


### PR DESCRIPTION
The "Connection to PSA" page was not showing step 1 with the link to Opel login page due to a type error. As parse_qs() returns a list, we have to use first element.

Fixes #808