### PR TITLE
API changes for Homeassistant

### DIFF
--- a/psa_car_controller/web/view/api.py
+++ b/psa_car_controller/web/view/api.py
@@ -190,7 +190,7 @@ def settings_section(section: str):
 @app.route('/vehicles/trips')
 def get_trips():
     try:
-    homeassistant = request.args.get('homeassistant', None)
+        homeassistant = request.args.get('homeassistant', None)
         car = APP.myp.vehicles_list[0]
         trips_by_vin = Trips.get_trips(Cars([car]))
         trips = trips_by_vin[car.vin]
@@ -210,11 +210,18 @@ def get_trips():
 @app.route('/vehicles/chargings')
 def get_chargings():
     try:
+        homeassistant = request.args.get('homeassistant', None)
         chargings = Charging.get_chargings()
-        return jsonify(chargings)
+        if homeassistant is not None:
+            return jsonify({"chargings": chargings})
+        else:
+            return jsonify(chargings)
     except (IndexError, TypeError):
         logger.debug("Failed to get chargings, there is probably not enough data yet:", exc_info=True)
-        return jsonify([])
+        if homeassistant is not None:
+            return jsonify({"chargings": [])
+        else:
+            return jsonify([])
 
 
 @app.route('/settings')

--- a/psa_car_controller/web/view/api.py
+++ b/psa_car_controller/web/view/api.py
@@ -202,7 +202,7 @@ def get_trips():
     except (IndexError, TypeError):
         logger.debug("Failed to get trips, there is probably not enough data yet:", exc_info=True)
         if homeassistant is not None:
-            return jsonify({"trips": [])
+            return jsonify({"trips": []})
         else:
             return jsonify([])
 
@@ -219,7 +219,7 @@ def get_chargings():
     except (IndexError, TypeError):
         logger.debug("Failed to get chargings, there is probably not enough data yet:", exc_info=True)
         if homeassistant is not None:
-            return jsonify({"chargings": [])
+            return jsonify({"chargings": []})
         else:
             return jsonify([])
 

--- a/psa_car_controller/web/view/api.py
+++ b/psa_car_controller/web/view/api.py
@@ -190,14 +190,21 @@ def settings_section(section: str):
 @app.route('/vehicles/trips')
 def get_trips():
     try:
+    homeassistant = request.args.get('homeassistant', None)
         car = APP.myp.vehicles_list[0]
         trips_by_vin = Trips.get_trips(Cars([car]))
         trips = trips_by_vin[car.vin]
         trips_as_dict = trips.get_trips_as_dict()
-        return jsonify(trips_as_dict)
+        if homeassistant is not None:
+            return jsonify({"trips": trips_as_dict})
+        else:
+            return jsonify(trips_as_dict)
     except (IndexError, TypeError):
         logger.debug("Failed to get trips, there is probably not enough data yet:", exc_info=True)
-        return jsonify([])
+        if homeassistant is not None:
+            return jsonify({"trips": [])
+        else:
+            return jsonify([])
 
 
 @app.route('/vehicles/chargings')


### PR DESCRIPTION
If you want to get the trips or chargings with Homeassistant RESTful Sensor into an attribute (e.g. to create a table) you need a json attribute. So we have to implement a attribute with the array to parse the trip and charge data to homeassistant.

After that you can use:

```
- platform: rest
  name: corsa_e_trips
  resource: http://xxxxx:5000/vehicles/trips?homeassistant=1
  scan_interval: 60
  value_template: "{{ value_json | length }}"
  json_attributes:
  - trips
```
While now you cant parse the json into an attribute and the value only allows 255 chars.

After that you can e.g. use `flex-table-card` to create a nice table with a list of your trips or charges.

