### PR TITLE
Update car_models.yml

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -503,7 +503,7 @@
   battery_power: 50
   fuel_capacity: 0
   abrp_name: opel:comboe:22:50
-  reg: W0VEZZKXZN.*
+  reg: W0VEZZKXZ.*
   max_elec_consumption: 45 
 - !CarModel
   name: New 308 SW


### PR DESCRIPTION
My Opel Combo-e Life has the first 10 digits

W0VEZZKXZM

It isn't recognize by PSA.

Reduce to 9 digits should solve the problem.