### PR TITLE
Connect to SQLite using WAL mode

### DIFF
--- a/psa_car_controller/psacc/repository/db.py
+++ b/psa_car_controller/psacc/repository/db.py
@@ -40,6 +40,7 @@ class CustomSqliteConnection(sqlite3.Connection):
     def __init__(self, *args, **kwargs):  # real signature unknown
         super().__init__(*args, **kwargs)
         self.callbacks = []
+        self.execute("PRAGMA journal_mode=WAL;")
 
     def execute_callbacks(self):
         for callback in self.callbacks:


### PR DESCRIPTION
Significantly speeds up all database requests and should solve the dreaded "database is currently locked" issue that shows up from time to time. See https://www.sqlite.org/wal.html