### PR TITLE
Added Peugeot E-Partner 50 kWh (2024)

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -661,3 +661,10 @@
   fuel_capacity: 52
   abrp_name:
   reg: VR3FPHNSTP.*
+- !ElecModel
+  name: E-Partner 50 kWh (2024)
+  battery_power: 50
+  fuel_capacity: 0
+  abrp_name: Peugeot;Partner (alpha)
+  reg: VR3ENZKUXR.*
+  max_elec_consumption: 50


### PR DESCRIPTION
- !ElecModel name: Peugeot E-Partner 50 kWh (2024) battery_power: 50 fuel_capacity: 0 abrp_name: Peugeot;Partner (alpha) reg: VR3ENZKUXR.* max_elec_consumption: 50