### PR TITLE
Car models updated for peugeot 208 2017-2019

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -196,6 +196,14 @@
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !CarModel
+  name: '208(2017-2019)'
+  battery_power: 0
+  fuel_capacity: 44
+  abrp_name: 
+  reg: VF3CCHMRPJ.*
+  max_elec_consumption: 70
+  max_fuel_consumptipn: 30
+- !CarModel
   name: '2008'
   battery_power: 0
   fuel_capacity: 44


### PR DESCRIPTION
Added Peugeot 208 2017-2019 (aka Peugeot 208 old). These cars have connected sims therefore support some features.