### PR TITLE
Added Peugeot E-308 Allure to car_models.yml

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -661,3 +661,9 @@
   fuel_capacity: 52
   abrp_name:
   reg: VR3FPHNSTP.*
+- !CarModel
+  name: E-308 Allure
+  battery_power: 50
+  fuel_capacity: 0
+  abrp_name: peugeot:e308:23:54
+  reg: VR3FMZKW3R.*


### PR DESCRIPTION
* Added Peugeot E-308 Allure because of error:

``` log
2025-01-01 15:33:18,674 :: WARNING :: Can't get car model, please report an issue on github with your car model and first ten letter of your VIN : VR3FMZKW3R
2025-01-01 15:33:18,674 :: ERROR :: finish_oauth:
Traceback (most recent call last):
File "/usr/local/lib/python3.9/dist-packages/psa_car_controller/web/view/config_oauth.py", line 56, in finish_oauth
config_views.INITIAL_SETUP.connect(code)
File "/usr/local/lib/python3.9/dist-packages/psa_car_controller/psa/setup/app_decoder.py", line 114, in connect
res = self.psacc.get_vehicles()
File "/usr/local/lib/python3.9/dist-packages/psa_car_controller/psacc/application/psa_client.py", line 142, in get_vehicles
self.vehicles_list.add(Car(vehicle.vin, vehicle.id, vehicle.brand, vehicle.label))
File "/usr/local/lib/python3.9/dist-packages/psa_car_controller/psacc/model/car.py", line 28, in __init__
self.max_elec_consumption = max_elec_consumption or model.max_elec_consumption # kwh/100Km
AttributeError: 'CarModel' object has no attribute 'max_elec_consumption'
```