### PR TITLE
OpenWeatherMap One Call API 3.0

### DIFF
--- a/psa_car_controller/psacc/utils/utils.py
+++ b/psa_car_controller/psacc/utils/utils.py
@@ -10,7 +10,7 @@ TIMEOUT_IN_S = 10
 def get_temp(latitude: str, longitude: str, api_key: str) -> float:
     try:
         if latitude and longitude and api_key:
-            weather_rep = requests.get("https://api.openweathermap.org/data/2.5/onecall",
+            weather_rep = requests.get("https://api.openweathermap.org/data/3.0/onecall",
                                        params={"lat": latitude, "lon": longitude,
                                                "exclude": "minutely,hourly,daily,alerts",
                                                "appid": api_key,


### PR DESCRIPTION
Since the OpenWeatherMap One Call API 2.5 is deprecated since June 2024, its time to use the 3.0 version.