### PR TITLE
feat: add model Vauxhall Corsa Electric

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -95,6 +95,14 @@
   max_elec_consumption: 70
   max_fuel_consumption: 0
 - !ElecModel
+  name: Vauxhall Corsa Electric
+  battery_power: 46
+  fuel_capacity: 0
+  abrp_name: vauxhall:corsae:20:50
+  reg: VXKUPHNEKP 
+  max_elec_consumption: 70
+  max_fuel_consumption: 0
+- !ElecModel
   name: DS3 Crossback e-tense
   battery_power: 46
   fuel_capacity: 0


### PR DESCRIPTION
The Opel Corsa already exists. This is just the Vauxhall equivalent.