### PR TITLE
Fix OTP SHA256 issue during OTP process. Change Dockerfile to build on official Python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,18 @@
-ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
-FROM debian:bookworm-slim AS builder
-ARG PSACC_VERSION="0.0.0"
-ARG PYTHON_DEP
-RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion ninja-build' ; \
-     apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;
-RUN pip3 install --break-system-packages --upgrade pip wheel setuptools
-COPY ./dist/psa_car_controller-${PSACC_VERSION}-py3-none-any.whl .
-RUN pip3 install --break-system-packages --no-cache-dir psa_car_controller-${PSACC_VERSION}-py3-none-any.whl
-EXPOSE 5000
+FROM python:3.10-slim AS builder
+WORKDIR /tmp
+COPY ./pyproject.toml /tmp/
+COPY ./psa_car_controller/ /tmp/psa_car_controller/
+RUN pip3 install --break-system-packages --upgrade pip wheel setuptools build
+RUN python3 -m build
 
-FROM debian:bookworm-slim
-ARG PYTHON_DEP
+EXPOSE 5000
+FROM python:3.10-slim
+ARG PSACC_VERSION="0.0.0"
 WORKDIR /config
 ENV PSACC_BASE_PATH=/ PSACC_PORT=5000 PSACC_OPTIONS="-c -r --web-conf" PSACC_CONFIG_DIR="/config" PYTHONPATH="/app"
-COPY --from=builder /var/lib/apt /var/lib/apt
-COPY --from=builder /var/cache/apt/ /var/cache/apt/
-COPY --from=builder /usr/local/lib /usr/local/lib
-COPY --from=builder /usr/local/bin/  /usr/local/bin/
-RUN  apt-get install -y --no-install-recommends $PYTHON_DEP curl && \
-     apt-get clean ; \
-     rm -rf /var/lib/apt/lists/*
+COPY --from=builder /tmp/dist/ /config/dist/
+RUN pip3 install --break-system-packages dist/psa_car_controller-${PSACC_VERSION}-py3-none-any.whl
+RUN rm -r /config/dist
 COPY /docker_files/init.sh /init.sh
-CMD /init.sh
+CMD [ "/init.sh" ] 

--- a/docker_files/init.sh
+++ b/docker_files/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo "Containerised psa_car_controller loading..."
 cd "$PSACC_CONFIG_DIR"
-ARGS="-p $PSACC_PORT -l 0.0.0.0 -b $PSACC_BASE_PATH $PSACC_OPTIONS"
+ARGS="-p $PSACC_PORT -l 0.0.0.0 -b $PSACC_BASE_PATH $PSACC_OPTIONS" -R 15
 psa-car-controller $ARGS

--- a/psa_car_controller/psa/otp/otp.py
+++ b/psa_car_controller/psa/otp/otp.py
@@ -10,6 +10,7 @@ import requests
 from Cryptodome.Cipher import AES
 from Cryptodome.PublicKey import RSA
 from Cryptodome import Hash
+from Cryptodome.Hash import SHA256
 
 from . import oaep
 from .load import IWData


### PR DESCRIPTION
Allowing psa-car-controller to build within a container then installed in a separate Python base image, which in turn is based on Debian. This will speed up build process.

Allow building of psa-car-controller in a container.

Fixed OTP SHA256 error during OTP process.