### PR TITLE
Fix energy.py updated handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ certs/
 *.log.*
 
 .vscode/
+psa-car-controller-fre.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="0.0.0"
+ARG PSACC_VERSION="3.3.2.1"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="3.4.1.2"
+ARG PSACC_VERSION="3.4.2.1"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="3.5.1.1"
+ARG PSACC_VERSION="3.5.6.1"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion ninja-build' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="3.4.0.1"
+ARG PSACC_VERSION="3.4.1.2"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="3.5.0.1"
+ARG PSACC_VERSION="3.5.1.1"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="3.4.2.1"
+ARG PSACC_VERSION="3.5.0.1"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ RUN  apt-get install -y --no-install-recommends $PYTHON_DEP && \
      apt-get clean ; \
      rm -rf /var/lib/apt/lists/*
 COPY /docker_files/init.sh /init.sh
+RUN chmod 755 /init.sh
 CMD /init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_DEP='python3 python3-wheel python3-typing-extensions python3-pandas python3-six python3-dateutil python3-brotli python3-pycryptodome libatlas3-base python3-cryptography python3-scipy androguard python3-flask python3-paho-mqtt python3-ruamel.yaml ca-certificates python3-numpy'
 ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:bullseye-slim AS builder
-ARG PSACC_VERSION="3.3.2.1"
+ARG PSACC_VERSION="3.4.0.1"
 ARG PYTHON_DEP
 RUN  BUILD_DEP='python3-pip python3-setuptools python3-dev libblas-dev liblapack-dev gfortran libffi-dev libxml2-dev libxslt1-dev make automake gcc g++ subversion' ; \
      apt-get update && apt-get install -y --no-install-recommends $BUILD_DEP $PYTHON_DEP;

--- a/local-build.txt
+++ b/local-build.txt
@@ -1,0 +1,8 @@
+pip wheel -w dist .
+docker build --platform linux/arm/v8 -t fre42/psa-car-controller:v3.5.3.1 .
+docker save fre42/psa-car-controller:v3.5.1.1 -o .\psa-car-controller-fre.tgz
+
+Dann per MobaXterm hochladen auf den Pi
+
+Dort 
+docker image load -i psa-car-controller-fre.tgz

--- a/psa_car_controller/psa/RemoteClient.py
+++ b/psa_car_controller/psa/RemoteClient.py
@@ -96,7 +96,9 @@ class RemoteClient:
                     # fix a psa server bug where charge beginning without status api being properly updated
                     logger.warning("charge begin but API isn't updated")
                     time.sleep(60)
-                    self.wakeup(vin)
+                    #fre42: commented out since psa cloud sends wrong infos sometimes which causes psacc waking up endlessly
+                    # until the car goes to eco mode and blocks any connection
+                    #self.wakeup(vin)
             except (IndexError, AttributeError, RateLimitException):
                 logger.exception("on_mqtt_message:")
 
@@ -217,7 +219,8 @@ class RemoteClient:
         logger.info(msg)
         self.publish(msg)
 
-    @rate_limit(6, 60 * 20)
+    #@rate_limit(6, 60 * 20) // 6 times in 20 minutes is too often and will cause the car (at least the Opel Corsa) to go to eco mode
+    @rate_limit(4, 60 * 60)
     def wakeup(self, vin):
         logger.info("ask wakeup to %s", vin)
         msg = self.mqtt_request(vin, {"action": "state"}, "/VehCharge/state")

--- a/psa_car_controller/psa/connected_car_api/models/energy.py
+++ b/psa_car_controller/psa/connected_car_api/models/energy.py
@@ -32,6 +32,7 @@ class Energy(object):
     """
     swagger_types = {
         'updated_at': 'datetime',
+        'created_at': 'datetime',
         'autonomy': 'float',
         'battery': 'EnergyBattery',
         'charging': 'EnergyCharging',
@@ -42,7 +43,8 @@ class Energy(object):
     }
 
     attribute_map = {
-        'updated_at': 'createdAt',
+        'created_at': 'createdAt',
+        'updated_at': 'updatedAt',
         'autonomy': 'autonomy',
         'battery': 'battery',
         'charging': 'charging',

--- a/psa_car_controller/psa/connected_car_api/models/energy.py
+++ b/psa_car_controller/psa/connected_car_api/models/energy.py
@@ -54,10 +54,11 @@ class Energy(object):
         'type': 'type'
     }
 
-    def __init__(self, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
+    def __init__(self, created_at=None, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
         """Energy - a model defined in Swagger"""  # noqa: E501
 
         self._updated_at = None
+        self._created_at = None
         self._autonomy = None
         self._battery = None
         self._charging = None
@@ -69,6 +70,8 @@ class Energy(object):
 
         if updated_at is not None:
             self.updated_at = updated_at
+        if created_at is not None:
+            self.created_at = created_at
         if autonomy is not None:
             self.autonomy = autonomy
         if battery is not None:
@@ -83,6 +86,40 @@ class Energy(object):
             self.residual = residual
         if type is not None:
             self.type = type
+
+    @property
+    def created_at(self):
+        """Gets the creazed of this Energy.  # noqa: E501
+
+        Date when the resource has been created.  # noqa: E501
+
+        :return: The creation of this Energy.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @property
+    def created_at(self):
+        """Gets the created_at of this Energy.  # noqa: E501
+
+        Date when the resource has been created.  # noqa: E501
+
+        :return: The created_at of this Energy.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @created_at.setter
+    def created_at(self, created_at):
+        """Sets the created_at of this Energy.
+
+        Date when the resource has been created.  # noqa: E501
+
+        :param created_at: The created_at of this Energy.  # noqa: E501
+        :type: datetime
+        """
+
+        self._created_at = created_at
 
     @property
     def updated_at(self):

--- a/psa_car_controller/psa/connected_car_api/models/energy.py
+++ b/psa_car_controller/psa/connected_car_api/models/energy.py
@@ -32,6 +32,7 @@ class Energy(object):
     """
     swagger_types = {
         'updated_at': 'datetime',
+        'created_at': 'datetime',
         'autonomy': 'float',
         'battery': 'EnergyBattery',
         'charging': 'EnergyCharging',
@@ -42,7 +43,8 @@ class Energy(object):
     }
 
     attribute_map = {
-        'updated_at': 'createdAt',
+        'created_at': 'createdAt',
+        'updated_at': 'updatedAt',
         'autonomy': 'autonomy',
         'battery': 'battery',
         'charging': 'charging',
@@ -52,10 +54,11 @@ class Energy(object):
         'type': 'type'
     }
 
-    def __init__(self, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
+    def __init__(self, created_at=None, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
         """Energy - a model defined in Swagger"""  # noqa: E501
 
         self._updated_at = None
+        self._created_at = None
         self._autonomy = None
         self._battery = None
         self._charging = None
@@ -67,6 +70,8 @@ class Energy(object):
 
         if updated_at is not None:
             self.updated_at = updated_at
+        if created_at is not None:
+            self.created_at = created_at
         if autonomy is not None:
             self.autonomy = autonomy
         if battery is not None:
@@ -81,6 +86,40 @@ class Energy(object):
             self.residual = residual
         if type is not None:
             self.type = type
+
+    @property
+    def created_at(self):
+        """Gets the creazed of this Energy.  # noqa: E501
+
+        Date when the resource has been created.  # noqa: E501
+
+        :return: The creation of this Energy.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @property
+    def created_at(self):
+        """Gets the created_at of this Energy.  # noqa: E501
+
+        Date when the resource has been created.  # noqa: E501
+
+        :return: The created_at of this Energy.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @created_at.setter
+    def created_at(self, created_at):
+        """Sets the created_at of this Energy.
+
+        Date when the resource has been created.  # noqa: E501
+
+        :param created_at: The created_at of this Energy.  # noqa: E501
+        :type: datetime
+        """
+
+        self._created_at = created_at
 
     @property
     def updated_at(self):

--- a/psa_car_controller/psa/connected_car_api/models/energy.py
+++ b/psa_car_controller/psa/connected_car_api/models/energy.py
@@ -32,7 +32,6 @@ class Energy(object):
     """
     swagger_types = {
         'updated_at': 'datetime',
-        'created_at': 'datetime',
         'autonomy': 'float',
         'battery': 'EnergyBattery',
         'charging': 'EnergyCharging',
@@ -43,8 +42,7 @@ class Energy(object):
     }
 
     attribute_map = {
-        'created_at': 'createdAt',
-        'updated_at': 'updatedAt',
+        'updated_at': 'createdAt',
         'autonomy': 'autonomy',
         'battery': 'battery',
         'charging': 'charging',
@@ -54,11 +52,10 @@ class Energy(object):
         'type': 'type'
     }
 
-    def __init__(self, created_at=None, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
+    def __init__(self, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
         """Energy - a model defined in Swagger"""  # noqa: E501
 
         self._updated_at = None
-        self._created_at = None
         self._autonomy = None
         self._battery = None
         self._charging = None
@@ -70,8 +67,6 @@ class Energy(object):
 
         if updated_at is not None:
             self.updated_at = updated_at
-        if created_at is not None:
-            self.created_at = created_at
         if autonomy is not None:
             self.autonomy = autonomy
         if battery is not None:
@@ -86,40 +81,6 @@ class Energy(object):
             self.residual = residual
         if type is not None:
             self.type = type
-
-    @property
-    def created_at(self):
-        """Gets the creazed of this Energy.  # noqa: E501
-
-        Date when the resource has been created.  # noqa: E501
-
-        :return: The creation of this Energy.  # noqa: E501
-        :rtype: datetime
-        """
-        return self._created_at
-
-    @property
-    def created_at(self):
-        """Gets the created_at of this Energy.  # noqa: E501
-
-        Date when the resource has been created.  # noqa: E501
-
-        :return: The created_at of this Energy.  # noqa: E501
-        :rtype: datetime
-        """
-        return self._created_at
-
-    @created_at.setter
-    def created_at(self, created_at):
-        """Sets the created_at of this Energy.
-
-        Date when the resource has been created.  # noqa: E501
-
-        :param created_at: The created_at of this Energy.  # noqa: E501
-        :type: datetime
-        """
-
-        self._created_at = created_at
 
     @property
     def updated_at(self):

--- a/psa_car_controller/psacc/application/charge_control.py
+++ b/psa_car_controller/psacc/application/charge_control.py
@@ -67,7 +67,9 @@ class ChargeControl:
             wakeup_timeout = self.wakeup_timeout
         if (datetime.utcnow().replace(tzinfo=pytz.UTC) - last_update).total_seconds() > 60 * wakeup_timeout:
             try:
-                self.psacc.remote_client.wakeup(self.vin)
+                pass
+    #fre42: commented out since psa cloud does not update the "updated_at" field
+   #             self.psacc.remote_client.wakeup(self.vin)
             except RateLimitException:
                 logger.exception("force_update:")
 

--- a/psa_car_controller/psacc/application/psa_client.py
+++ b/psa_car_controller/psacc/application/psa_client.py
@@ -83,7 +83,7 @@ class PSAClient:
         return realm_info[self.realm]['app_name']
 
     def api(self) -> VehiclesApi:
-        self.api_config.access_token = self.manager.acceschs_token
+        self.api_config.access_token = self.manager.access_token
         api_instance = VehiclesApi(OauthAPIClient(self.api_config))
         return api_instance
 

--- a/psa_car_controller/psacc/application/psa_client.py
+++ b/psa_car_controller/psacc/application/psa_client.py
@@ -83,7 +83,7 @@ class PSAClient:
         return realm_info[self.realm]['app_name']
 
     def api(self) -> VehiclesApi:
-        self.api_config.access_token = self.manager.access_token
+        self.api_config.access_token = self.manager.acceschs_token
         api_instance = VehiclesApi(OauthAPIClient(self.api_config))
         return api_instance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "3.4.1.2"
+version = "3.4.2.1"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "3.4.0.1"
+version = "3.4.1.2"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "3.3.2.1"
+version = "3.4.0.1"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "3.5.0.1"
+version = "3.5.1.1"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "3.4.2.1"
+version = "3.5.0.1"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "0.0.0"
+version = "3.3.2.1"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "psa-car-controller"
-version = "3.5.1.1"
+version = "3.5.6.1"
 description = "This is a python program to control a psa car with connected_car v4 api."
 authors = ["Florian Bezannier <florian.bezannier@hotmail.fr>"]
 license = "GPL-3.0"


### PR DESCRIPTION
It looks as if Stellantis/PSA has changed the data record for the “energy” tag. Previously there was only one field “created_at”, which the psa_car_controller transferred to the vehicleInfo json as “updated_at”. 
However, the Stellantis server now also sends an updated_at. As expected, it now contains the time of the last change. The created_at field remains at an old status and may no longer change.
As a result, psa_car_controller always returns this old time as “updated_at” and not the correct value. If you now look at this time to see whether something has changed, you will always see the old date.
I have no introduced a new field "created_at" at psa_car_controller's vehicleInfo json and will now read udpated_at from the new updated_at field from Stellantis server.