### PR TITLE
fix updated_at handling for energy json tag

### DIFF
--- a/psa_car_controller/psa/connected_car_api/models/energy.py
+++ b/psa_car_controller/psa/connected_car_api/models/energy.py
@@ -32,6 +32,7 @@ class Energy(object):
     """
     swagger_types = {
         'updated_at': 'datetime',
+        'created_at': 'datetime',
         'autonomy': 'float',
         'battery': 'EnergyBattery',
         'charging': 'EnergyCharging',
@@ -42,7 +43,8 @@ class Energy(object):
     }
 
     attribute_map = {
-        'updated_at': 'createdAt',
+        'created_at': 'createdAt',
+        'updated_at': 'updatedAt',
         'autonomy': 'autonomy',
         'battery': 'battery',
         'charging': 'charging',
@@ -52,10 +54,11 @@ class Energy(object):
         'type': 'type'
     }
 
-    def __init__(self, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
+    def __init__(self, created_at=None, updated_at=None, autonomy=None, battery=None, charging=None, consumption=None, level=None, residual=None, type=None):  # noqa: E501
         """Energy - a model defined in Swagger"""  # noqa: E501
 
         self._updated_at = None
+        self._created_at = None
         self._autonomy = None
         self._battery = None
         self._charging = None
@@ -67,6 +70,8 @@ class Energy(object):
 
         if updated_at is not None:
             self.updated_at = updated_at
+        if created_at is not None:
+            self.created_at = created_at
         if autonomy is not None:
             self.autonomy = autonomy
         if battery is not None:
@@ -81,6 +86,40 @@ class Energy(object):
             self.residual = residual
         if type is not None:
             self.type = type
+
+    @property
+    def created_at(self):
+        """Gets the creazed of this Energy.  # noqa: E501
+
+        Date when the resource has been created.  # noqa: E501
+
+        :return: The creation of this Energy.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @property
+    def created_at(self):
+        """Gets the created_at of this Energy.  # noqa: E501
+
+        Date when the resource has been created.  # noqa: E501
+
+        :return: The created_at of this Energy.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @created_at.setter
+    def created_at(self, created_at):
+        """Sets the created_at of this Energy.
+
+        Date when the resource has been created.  # noqa: E501
+
+        :param created_at: The created_at of this Energy.  # noqa: E501
+        :type: datetime
+        """
+
+        self._created_at = created_at
 
     @property
     def updated_at(self):


### PR DESCRIPTION
It looks as if Stellantis/PSA has changed the data record for the “energy” tag. Previously there was only one field “created_at”, which the psa_car_controller transferred to the vehicleInfo json as “updated_at”. 
However, the Stellantis server now also sends an updated_at. As expected, it now contains the time of the last change. The created_at field remains at an old status and may no longer change.
As a result, psa_car_controller always returns this old time as “updated_at” and not the correct value. If you now look at this time to see whether something has changed, you will always see the old date.
I have no introduced a new field "created_at" at psa_car_controller's vehicleInfo json and will now read udpated_at from the new updated_at field from Stellantis server.
The web ui control panel refresh/wakeup icon will now also have the correct timestamp.