### PR TITLE
fix: Cryptodome moved SHA256

### DIFF
--- a/psa_car_controller/psa/otp/otp.py
+++ b/psa_car_controller/psa/otp/otp.py
@@ -9,7 +9,7 @@ from xml.etree import cElementTree as ElT
 import requests
 from Cryptodome.Cipher import AES
 from Cryptodome.PublicKey import RSA
-from Cryptodome import Hash
+from Cryptodome.Hash import SHA256
 
 from . import oaep
 from .load import IWData
@@ -102,7 +102,7 @@ class Otp:
         self.pinmode = pinmode
         self.Kiw = self.decode_oaep(Kiw, self.Kfact)
         key = RSA.construct((int(self.Kiw, 16), Otp.exponent))
-        self.cipher = oaep.new(key, hash_algo=Hash.SHA256)
+        self.cipher = oaep.new(key, hash_algo=SHA256)
 
     def get_serial(self):
         return self.device_id + "/_/" + self.iwalea
@@ -135,7 +135,7 @@ class Otp:
     def decode_oaep(enc, key):
         modulus = int(key, 16)
         key = RSA.construct((modulus, Otp.exponent))
-        cipher = oaep.new(key, hash_algo=Hash.SHA256)
+        cipher = oaep.new(key, hash_algo=SHA256)
         block_size = 128
         dec_string = ""
         enc_b = bytes.fromhex(enc)
@@ -236,7 +236,7 @@ class Otp:
         self.action = "synchro"
         res = self.decode_oaep(xml["ms_key"], self.Kfact)
         temp_key = RSA.construct((int(res, 16), self.exponent))
-        temp_cipher = oaep.new(temp_key, hash_algo=Hash.SHA256)
+        temp_cipher = oaep.new(temp_key, hash_algo=SHA256)
         if random_bytes is None:
             random_bytes = token_bytes(16)
         kpub_encode = temp_cipher.encrypt(random_bytes)
@@ -291,7 +291,7 @@ class Otp:
         self.__dict__.update(dict_param)
         if self.Kiw is not None:
             key = RSA.construct((int(self.Kiw, 16), Otp.exponent))
-            self.cipher = oaep.new(key, hash_algo=Hash.SHA256)
+            self.cipher = oaep.new(key, hash_algo=SHA256)
 
     @staticmethod
     def set_proxies(proxies):
@@ -299,7 +299,7 @@ class Otp:
 
 
 def encode_oeap(text, key):
-    cipher = oaep.new(bytes.fromhex(key), hash_algo=Hash.SHA256)
+    cipher = oaep.new(bytes.fromhex(key), hash_algo=SHA256)
     return cipher.encrypt(text)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ argparse = "^1.4.0"
 geojson = "^2.5.0"
 reverse-geocode = "^1.4.1"
 androguard = "^4.1.2"
-pycryptodomex = "^3.9.0"
+pycryptodomex = "3.23.0"  # Pin version as they introduce breaking changes in minor versions
 pydantic = "^1.9.0"
 "ruamel.yaml" = ">=0.15.0"
 certifi = ">=14.05.14"


### PR DESCRIPTION
Cryptodome introduced a breaking change somewhere between versions `3.9.0` and `3.23.0`, which lead to `Hash.SHA256` not being found. This was only problem for newer installations not using docker as the installation spec `^3.9.0` allowed to install any minor newer than `3.9.0`.

This pull request fixes that problem while also pinning the version of Cryptodome. This prevents a breaking minor from breaking this project again.

Fixes #1075 