### PR TITLE
feat: trip end column

### DIFF
--- a/psa_car_controller/psacc/model/trip.py
+++ b/psa_car_controller/psacc/model/trip.py
@@ -75,13 +75,20 @@ class Trip:
                                                                "average consumption fuel": self.consumption_fuel_km})
 
     def get_info(self):
-
-        res = {"consumption_km": self.consumption_km, "start_at": self.start_at,
-               "consumption_by_temp": self.get_temperature(), "positions": self.get_positions(),
-               "duration": self.duration * 60, "speed_average": self.speed_average, "distance": self.distance,
-               "mileage": self.mileage, "altitude_diff": self.altitude_diff, "id": self.id,
-               "consumption": self.consumption
-               }
+        res = {
+            "consumption_km": self.consumption_km,
+            "start_at": self.start_at,
+            "end_at": self.end_at,
+            "consumption_by_temp": self.get_temperature(),
+            "positions": self.get_positions(),
+            "duration": self.duration * 60,
+            "speed_average": self.speed_average,
+            "distance": self.distance,
+            "mileage": self.mileage,
+            "altitude_diff": self.altitude_diff,
+            "id": self.id,
+            "consumption": self.consumption,
+        }
         if self.car.has_battery():
             res["consumption_km"] = self.consumption_km
 

--- a/psa_car_controller/web/figures.py
+++ b/psa_car_controller/web/figures.py
@@ -84,6 +84,7 @@ def get_figures(car: Car):
         },
         columns=[{'id': 'id', 'name': '#', 'type': 'numeric'},
                  {'id': 'start_at_str', 'name': 'start at', 'type': 'datetime'},
+                 {'id': 'end_at_str', 'name': 'end at', 'type': 'datetime'},
                  {'id': 'duration', 'name': 'duration', 'type': 'numeric',
                   'format': deepcopy(nb_format).symbol_suffix(" min").precision(0)},
                  {'id': 'speed_average', 'name': 'avg. speed', 'type': 'numeric',

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -208,6 +208,7 @@ class TestUnit(unittest.TestCase):
         res = trip.get_info()
         assert compare_dict(res, {'consumption_km': 24.21052631578947,
                                   'start_at': date0,
+                                  'end_at': date2,
                                   'consumption_by_temp': None,
                                   'positions': {'lat': [latitude], 'long': [longitude]},
                                   'duration': 40.0, 'speed_average': 28.5, 'distance': 19.0, 'mileage': 30.0,
@@ -266,6 +267,7 @@ class TestUnit(unittest.TestCase):
         res = trips[car.vin].get_trips_as_dict()
         assert compare_dict(res, [{'consumption_km': 6.947368421052632,
                                    'start_at': date0,
+                                   'end_at': date2,
                                    'consumption_by_temp': None,
                                    'positions': {'lat': [latitude],
                                                  'long': [longitude]},
@@ -294,6 +296,7 @@ class TestUnit(unittest.TestCase):
         res = trips[car.vin].get_trips_as_dict()
         assert compare_dict(res, [{'consumption_km': 6.947368421052632,
                                    'start_at': start,
+                                   'end_at': end,
                                    'consumption_by_temp': None,
                                    'positions': {'lat': [latitude],
                                                  'long': [longitude]},


### PR DESCRIPTION
This adds the end time for each trip. Personally, I prefer to have both the end time as well as the duration, but I can see how other people think differently. Feel free to close if this is not desired.