### PR TITLE
Fix price adjustments for fast charging sessions

### DIFF
--- a/psa_car_controller/web/tools/utils.py
+++ b/psa_car_controller/web/tools/utils.py
@@ -79,7 +79,7 @@ def diff_dashtable(data, data_previous, row_id_name="row_id"):
     changes = []
     for idx, row in df_diff.iterrows():
         row.dropna(inplace=True)
-        for change in row.iteritems():
+        for change in row.items():
             changes.append(
                 {
                     row_id_name: data[idx][row_id_name],


### PR DESCRIPTION
Couldn’t edit the price of charging due to this error: `AttributeError: 'Series' object has no attribute 'iteritems'.` This PR changes `iteritems` to `items` in the code, following the deprecation notice from pandas:
https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.DataFrame.iteritems.html

```
car-opel-corsa-gs  | Traceback (most recent call last):
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1473, in wsgi_app
car-opel-corsa-gs  |     response = self.full_dispatch_request()
car-opel-corsa-gs  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 882, in full_dispatch_request
car-opel-corsa-gs  |     rv = self.handle_user_exception(e)
car-opel-corsa-gs  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 880, in full_dispatch_request
car-opel-corsa-gs  |     rv = self.dispatch_request()
car-opel-corsa-gs  |          ^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 865, in dispatch_request
car-opel-corsa-gs  |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
car-opel-corsa-gs  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/dash/dash.py", line 1376, in dispatch
car-opel-corsa-gs  |     ctx.run(
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/dash/_callback.py", line 507, in add_context
car-opel-corsa-gs  |     raise err
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/dash/_callback.py", line 496, in add_context
car-opel-corsa-gs  |     output_value = _invoke_callback(func, *func_args, **func_kwargs)
car-opel-corsa-gs  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/dash/_callback.py", line 43, in _invoke_callback
car-opel-corsa-gs  |     return func(*args, **kwargs)  # %% callback invoked %%
car-opel-corsa-gs  |            ^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/psa_car_controller/web/view/views.py", line 108, in capture_diffs_in_battery_table
car-opel-corsa-gs  |     diff_data = diff_dashtable(data, data_previous, "start_at")
car-opel-corsa-gs  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/psa_car_controller/web/tools/utils.py", line 82, in diff_dashtable
car-opel-corsa-gs  |     for change in row.items():
car-opel-corsa-gs  |                   ^^^^^^^^^^^^^
car-opel-corsa-gs  |   File "/usr/local/lib/python3.11/site-packages/pandas/core/generic.py", line 6321, in __getattr__
car-opel-corsa-gs  |     return object.__getattribute__(self, name)
car-opel-corsa-gs  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
car-opel-corsa-gs  | AttributeError: 'Series' object has no attribute 'iteritems'
```