### PR TITLE
feat: add model Citroen e-c3 Max 2025

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -761,7 +761,6 @@
   reg: VR7CBZYA9S
   max_elec_consumption: 70
 - !ElecModel
-- !ElecModel
   name: E-5008 73 kWh
   battery_power: 73
   fuel_capacity: 0

--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -732,6 +732,14 @@
   max_elec_consumption: 70
   max_fuel_consumption: 30
 - !ElecModel
+  name: Citroën e-C3 IV
+  battery_power: 44
+  fuel_capacity: 0
+  abrp_name: citroen:ec3:24:44
+  reg: VR7CBZYA9S
+  max_elec_consumption: 70
+- !ElecModel
+- !ElecModel
   name: E-5008 73 kWh
   battery_power: 73
   fuel_capacity: 0


### PR DESCRIPTION
added my e-c3 Max 2025 with another VIN and added abrp information as I got the "No vehicle in your account is compatible with this API, you vehicle is probably too old..." Error even though this is a brand new 2025 vehicle