### PR TITLE
bugfix: catch None values

### DIFF
--- a/psa_car_controller/psacc/application/trip_parser.py
+++ b/psa_car_controller/psacc/application/trip_parser.py
@@ -25,10 +25,14 @@ class TripParser:
 
     @staticmethod
     def get_thermal_consumption(start, end):
+        if start[LEVEL_FUEL] is None or end[LEVEL_FUEL] is None:
+            return [0, 0]
         return [0, start[LEVEL_FUEL] - end[LEVEL_FUEL]]
 
     @staticmethod
     def get_elec_consumption(start, end):
+        if start[LEVEL] is None or end[LEVEL] is None:
+            return [0, 0]
         return [start[LEVEL] - end[LEVEL], 0]
 
     @staticmethod


### PR DESCRIPTION
Due to the use of "None" values, subtraction errors and aborted operations occurred. This change addresses that issue.