### PR TITLE
Fix for broken trip & charge pages: add check for NoneType in get_elec_consumption

### DIFF
--- a/psa_car_controller/psacc/application/trip_parser.py
+++ b/psa_car_controller/psacc/application/trip_parser.py
@@ -31,8 +31,7 @@ class TripParser:
     def get_elec_consumption(start, end):
         if start[LEVEL] is not None and end[LEVEL] is not None:
             return [start[LEVEL] - end[LEVEL], 0]
-        else:
-            return [0, 0]
+        return [0, 0]
 
     @staticmethod
     def get_hybrid_consumption(start, end):

--- a/psa_car_controller/psacc/application/trip_parser.py
+++ b/psa_car_controller/psacc/application/trip_parser.py
@@ -29,7 +29,10 @@ class TripParser:
 
     @staticmethod
     def get_elec_consumption(start, end):
-        return [start[LEVEL] - end[LEVEL], 0]
+        if start[LEVEL] is not None and end[LEVEL] is not None:
+            return [start[LEVEL] - end[LEVEL], 0]
+        else:
+            return [0, 0]
 
     @staticmethod
     def get_hybrid_consumption(start, end):


### PR DESCRIPTION
As my trip data would no longer load. The log states that end[LEVEL] could be NoneType, which trip_parser did not like. With this check in place my trip data is working again.