### PR TITLE
feat: add model e-berlingo 2022+

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -69,6 +69,13 @@
   reg: VR7EZZKXZN 
   max_elec_consumption: 70
 - !ElecModel
+  name: e-berlingo 2022+
+  battery_power: 50
+  fuel_capacity: 0
+  abrp_name: Citroen;e-Berlingo;2022+
+  reg: VR7EMZKU5T
+  max_elec_consumption: 70
+- !ElecModel
   name: e-jumpy
   battery_power: 68
   fuel_capacity: 0


### PR DESCRIPTION
The VIN is for a 2024+ model actually, but that is yet to be seen on the abrp list.