### PR TITLE
chore: downgrade androguard from git master to 4.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -22,36 +22,29 @@ tz = ["tzdata"]
 
 [[package]]
 name = "androguard"
-version = "4.1.3"
+version = "4.0.2"
 description = "Androguard is a full python tool to play with Android files."
 optional = false
-python-versions = "^3.9"
+python-versions = ">=3.9,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "androguard-4.0.2-py3-none-any.whl", hash = "sha256:8a6bdb4d01a56a0274fe92d2e33a99bd0c053f0800a0785b18f9fcf4984b07cd"},
+    {file = "androguard-4.0.2.tar.gz", hash = "sha256:bdce1caff9bad9a9cf8b86509de7cd67a27a2cbf833d0b03ac7e0c52046f1847"},
+]
 
 [package.dependencies]
 apkInspector = ">=1.1.7"
 asn1crypto = ">=0.24.0"
 click = ">=7.0"
 colorama = ">=0.4.1"
-cryptography = "*"
 dataset = "*"
 frida = "*"
 ipython = ">=5.0.0"
 loguru = "*"
 lxml = ">=4.3.0"
 mutf8 = "*"
-networkx = "*"
 pydot = ">=1.4.1"
 pygments = ">=2.3.1"
-pyyaml = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/androguard/androguard.git"
-reference = "master"
-resolved_reference = "dd458bead6165975c3ef0b1b78eaf2450e4889d9"
 
 [[package]]
 name = "apkinspector"
@@ -1496,54 +1489,6 @@ files = [
 ]
 
 [[package]]
-name = "networkx"
-version = "3.6"
-description = "Python package for creating and manipulating graphs and networks"
-optional = false
-python-versions = ">=3.11"
-groups = ["main"]
-markers = "python_version >= \"3.13\""
-files = [
-    {file = "networkx-3.6-py3-none-any.whl", hash = "sha256:cdb395b105806062473d3be36458d8f1459a4e4b98e236a66c3a48996e07684f"},
-    {file = "networkx-3.6.tar.gz", hash = "sha256:285276002ad1f7f7da0f7b42f004bcba70d381e936559166363707fdad3d72ad"},
-]
-
-[package.extras]
-benchmarking = ["asv", "virtualenv"]
-default = ["matplotlib (>=3.8)", "numpy (>=1.25)", "pandas (>=2.0)", "scipy (>=1.11.2)"]
-developer = ["mypy (>=1.15)", "pre-commit (>=4.1)"]
-doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=10)", "pydata-sphinx-theme (>=0.16)", "sphinx (>=8.0)", "sphinx-gallery (>=0.18)", "texext (>=0.6.7)"]
-example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "iplotx (>=0.9.0)", "momepy (>=0.7.2)", "osmnx (>=2.0.0)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
-extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
-release = ["build (>=0.10)", "changelist (==0.5)", "twine (>=4.0)", "wheel (>=0.40)"]
-test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
-test-extras = ["pytest-mpl", "pytest-randomly"]
-
-[[package]]
-name = "networkx"
-version = "3.6.1"
-description = "Python package for creating and manipulating graphs and networks"
-optional = false
-python-versions = "!=3.14.1,>=3.11"
-groups = ["main"]
-markers = "python_version < \"3.13\""
-files = [
-    {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
-    {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
-]
-
-[package.extras]
-benchmarking = ["asv", "virtualenv"]
-default = ["matplotlib (>=3.8)", "numpy (>=1.25)", "pandas (>=2.0)", "scipy (>=1.11.2)"]
-developer = ["mypy (>=1.15)", "pre-commit (>=4.1)"]
-doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=10)", "pydata-sphinx-theme (>=0.16)", "sphinx (>=8.0)", "sphinx-gallery (>=0.18)", "texext (>=0.6.7)"]
-example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "iplotx (>=0.9.0)", "momepy (>=0.7.2)", "osmnx (>=2.0.0)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
-extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
-release = ["build (>=0.10)", "changelist (==0.5)", "twine (>=4.0)", "wheel (>=0.40)"]
-test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
-test-extras = ["pytest-mpl", "pytest-randomly"]
-
-[[package]]
 name = "nodeenv"
 version = "1.10.0"
 description = "Node.js virtual environment builder"
@@ -2421,7 +2366,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -3017,4 +2962,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <4.0.0"
-content-hash = "1c65f0e89ca504a2fd2ab17eff6ceacb4a08dcb703aad0ebe678df8e61aa7825"
+content-hash = "edad0bfba8f8507a28dfb24c4db3bd1b7a9a99a94b26494ec567b17cb32eef16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pytz = "^2021.0"
 argparse = "^1.4.0"
 geojson = "^2.5.0"
 reverse-geocode = "^1.4.1"
-androguard = { git = "https://github.com/androguard/androguard.git", branch = "master" }
+androguard = "4.0.2"
 playwright = ">=1.40.0"
 pycryptodomex = "3.23.0"  # Pin version as they introduce breaking changes in minor versions
 pydantic = "^1.9.0"


### PR DESCRIPTION
Downgrade androguard dependency from git master branch to stable version 4.0.2.

This change:
- Replaces the git dependency on androguard master branch with a pinned PyPI version
- Updates poetry.lock accordingly
- Ensures reproducible builds with a known stable version

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>