### PR TITLE
fix: otp config success go to home

### DIFF
--- a/psa_car_controller/web/view/config_views.py
+++ b/psa_car_controller/web/view/config_views.py
@@ -96,6 +96,8 @@ config_otp_layout = dbc.Row(dbc.Col(className="col-md-12 col-lg-2 m-3", children
         html.Div([
             dbc.Button("Submit", color="primary", id="finish-otp"),
             html.Div(id="opt-result")]),
+        dcc.Location(id="otp-redirect-url", refresh=True),
+        dcc.Interval(id="otp-redirect-interval", interval=5000, n_intervals=0, disabled=True),
     ])]))
 
 
@@ -219,7 +221,8 @@ def askCode(n_clicks):  # pylint: disable=unused-argument
 
 
 @dash_app.callback(
-    Output("opt-result", "children"),
+    [Output("opt-result", "children"),
+     Output("otp-redirect-interval", "disabled")],
     Input("finish-otp", "n_clicks"),
     State("psa-pin", "value"),
     State("psa-code", "value"))
@@ -231,10 +234,22 @@ def finishOtp(n_clicks, code_pin, sms_code):  # pylint: disable=unused-argument
             app.myp.remote_client.otp = otp_session
             app.myp.save_config()
             app.start_remote_control()
-            return dbc.Alert(["OTP config finish !!! ", html.A(
-                "Go to home", href=dash_app.config.requests_pathname_prefix)], color="success")
+            home = dash_app.config.requests_pathname_prefix or "/"
+            alert = dbc.Alert(
+                ["OTP config finished! Redirecting to home in 5 seconds… ",
+                 html.A("Go to home now", href=home)], color="success")
+            return alert, False  # enable the interval -> auto-redirect
         except Exception as e:
             res = str(e)
             logger.exception("finishOtp:")
-            return dbc.Alert(res, color="danger")
+            return dbc.Alert(res, color="danger"), True  # keep interval disabled on error
+    raise PreventUpdate()
+
+
+@dash_app.callback(
+    Output("otp-redirect-url", "href"),
+    Input("otp-redirect-interval", "n_intervals"))
+def otp_redirect_home(n_intervals):
+    if n_intervals and n_intervals > 0:
+        return dash_app.config.requests_pathname_prefix or "/"
     raise PreventUpdate()

--- a/psa_car_controller/web/view/config_views.py
+++ b/psa_car_controller/web/view/config_views.py
@@ -234,7 +234,7 @@ def finishOtp(n_clicks, code_pin, sms_code):  # pylint: disable=unused-argument
             app.myp.remote_client.otp = otp_session
             app.myp.save_config()
             app.start_remote_control()
-            home = dash_app.config.requests_pathname_prefix or "/"
+            home = dash_app.get_relative_path("/")
             alert = dbc.Alert(
                 ["OTP config finished! Redirecting to home in 5 seconds… ",
                  html.A("Go to home now", href=home)], color="success")
@@ -251,5 +251,5 @@ def finishOtp(n_clicks, code_pin, sms_code):  # pylint: disable=unused-argument
     Input("otp-redirect-interval", "n_intervals"))
 def otp_redirect_home(n_intervals):
     if n_intervals and n_intervals > 0:
-        return dash_app.config.requests_pathname_prefix or "/"
+        return dash_app.get_relative_path("/")
     raise PreventUpdate()

--- a/psa_car_controller/web/view/views.py
+++ b/psa_car_controller/web/view/views.py
@@ -56,14 +56,13 @@ def add_header(el):
                              color="secondary",
                              className="me-1 bi bi-github",
                              external_link=True, href=github_url)
-    prefix = dash_app.config.requests_pathname_prefix or ""
-    return dbc.Row([dbc.Col(dcc.Link(html.H1('My car info'), href=prefix,
+    return dbc.Row([dbc.Col(dcc.Link(html.H1('My car info'), href=dash_app.get_relative_path("/"),
                                      style={"TextDecoration": "none"})),
                     dbc.Col(html.Div([dbc_version,
                                       dcc.Link(
                                           html.Img(src=dash_app.get_asset_url("images/settings.svg"),
                                                    width="30veh"),
-                                          href=prefix + "config",
+                                          href=dash_app.get_relative_path("/config"),
                                           className="float-end")],
                                      className="d-grid gap-2 d-md-flex justify-content-md-end",))],
                    className='align-items-center'), el


### PR DESCRIPTION
## Fix: navigation links not resolving to home (OTP setup + header)

### Problem
Several navigation links built their `href` by reading `requests_pathname_prefix`
directly. In non-ingress setups `MyProxyFix` sets that prefix to an empty string,
producing an empty/absent `href`. An empty `href` points at the current page, so:

- **OTP setup:** after finishing the initial OTP configuration, the success
  message's "Go to home" link reloaded the same OTP page instead of navigating
  home. With no visible navigation on success, setup felt like it hadn't worked —
  a false-positive.
- **Header logo:** "My car info" rendered an `<a>` with no usable `href`, making
  it non-clickable.

### Fix
Replaced the raw `requests_pathname_prefix` reads with Dash's built-in
`get_relative_path()` helper — the navigation-link equivalent of `get_asset_url()`,
which the project already uses for ingress-correct image paths. This resolves
correctly both locally and behind Home Assistant ingress:

- "Go to home" (OTP)  → `dash_app.get_relative_path("/")`
- "My car info"       → `dash_app.get_relative_path("/")`
- Settings icon       → `dash_app.get_relative_path("/config")`

Also added an automatic redirect after OTP completion: on success a
`dcc.Interval` (5s) is enabled, which drives a `dcc.Location(refresh=True)` to
reload the dashboard for users who don't click the link. On error the interval
stays disabled so the error remains visible.

### Result
Header and post-OTP links resolve to valid URLs in both local and ingress
deployments, and successful OTP setup now redirects to the dashboard on its own.
