### PR TITLE
Feature: Enable Manual Login as Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ certs/
 *.log.*
 
 .vscode/
+.DS_Store

--- a/psa_car_controller/web/view/config_oauth.py
+++ b/psa_car_controller/web/view/config_oauth.py
@@ -126,6 +126,8 @@ def finish_oauth(n_clicks, code):  # pylint: disable=unused-argument
     if ctx.triggered:
         try:
             config_views.INITIAL_SETUP.connect(code)
+            config_views.app.myp = config_views.INITIAL_SETUP.psacc
+            config_views.app.is_good = True
             return dbc.Alert(["PSA login finish !", html.A(" Go to otp config",
                              href=dash_app.config.requests_pathname_prefix + "config_otp")], color="success")
         except Exception as e:

--- a/psa_car_controller/web/view/config_oauth.py
+++ b/psa_car_controller/web/view/config_oauth.py
@@ -52,6 +52,11 @@ def setup_config_manual_layout():
                     dbc.FormText("Enter PSA OAuth Code", color="secondary")
                 ]),
                 dbc.Row(dbc.Button("Submit", color="primary", id="finish-oauth")),
+                dcc.Loading(
+                    id="loading-2",
+                    children=[html.Div([html.Div(id="oauth-result")])],
+                    type="circle",
+                ),
             ])
         ]),
     ])

--- a/psa_car_controller/web/view/config_oauth.py
+++ b/psa_car_controller/web/view/config_oauth.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 def setup_config_manual_layout():
     return dbc.Col(md=12, lg=2, className="m-3", children=[
         dbc.Row(html.H2('Connection to PSA (Advanced)')),
-        dbc.Row(html.A("Please follow the instructions here.", href="https://github.com/flobz/psa_car_controller/discussions/779")),
+        dbc.Row(html.A("Please follow the instructions here.",
+                       href="https://github.com/flobz/psa_car_controller/discussions/779")),
         dbc.Row(className="ms-2", children=[
             dbc.Form([
                 html.Div(className="mb-3", children=[

--- a/psa_car_controller/web/view/config_oauth.py
+++ b/psa_car_controller/web/view/config_oauth.py
@@ -3,6 +3,7 @@ import logging
 from dash import callback_context, html, dcc
 from dash.exceptions import PreventUpdate
 
+from psa_car_controller.psa.setup.app_decoder import InitialSetup
 from psa_car_controller.web.app import dash_app
 import dash_bootstrap_components as dbc
 from dash.dependencies import Output, Input, State
@@ -11,6 +12,49 @@ from psa_car_controller.web.view import config_views
 
 logger = logging.getLogger(__name__)
 
+# Page Layout for Manual OAuth Configuration
+def setup_config_manual_layout():
+    return dbc.Col(md=12, lg=2, className="m-3", children=[
+        dbc.Row(html.H2('Connection to PSA (Advanced)')),
+        dbc.Row(html.A("Please follow the instructions here.", href="https://github.com/flobz/psa_car_controller/discussions/779")),
+        dbc.Row(className="ms-2", children=[
+            dbc.Form([
+                html.Div(className="mb-3", children=[
+                    dbc.Label("Car Brand", html_for="psa-manual-app"),
+                    dcc.Dropdown(
+                        id="psa-manual-app",
+                        options=[
+                            {"label": "Peugeot", "value": "com.psa.mym.mypeugeot"},
+                            {"label": "Opel", "value": "com.psa.mym.myopel"},
+                            {"label": "Citroën", "value": "com.psa.mym.mycitroen"},
+                            {"label": "DS", "value": "com.psa.mym.myds"},
+                            {"label": "Vauxhall", "value": "com.psa.mym.myvauxhall"}
+                        ],
+                    )
+                ]),
+                html.Div(className="mb-3", children=[
+                    dbc.Label("Email", html_for="psa-manual-email"),
+                    dbc.Input(type="email", id="psa-manual-email", placeholder="Enter email"),
+                ]),
+                html.Div(className="mb-3", children=[
+                    dbc.Label("Password", html_for="psa-manual-password"),
+                    dbc.Input(type="password", id="psa-manual-password", placeholder="Enter password"),
+                ]),
+                html.Div(className="mb-3", children=[
+                    dbc.Label("Country code", html_for="psa-manual-countrycode"),
+                    dbc.Input(type="text", id="psa-manual-countrycode", placeholder="Enter your country code"),
+                ]),
+                dbc.Row(dbc.Button("Generate OAuth URL", color="primary", id="generate-manual-oauth")),
+                html.Div(id="manual-oauth-link", className="mt-3"),
+                html.Div(className="mb-3", children=[
+                    dbc.Label("Code", html_for="psa-oauth-code"),
+                    dbc.Input(type="text", id="psa-oauth-code", placeholder="Enter OAuth Code"),
+                    dbc.FormText("Enter PSA OAuth Code", color="secondary")
+                ]),
+                dbc.Row(dbc.Button("Submit", color="primary", id="finish-oauth")),
+            ])
+        ]),
+    ])
 
 def get_oauth_config_layout(redirect_url):
     return dbc.Row(dbc.Col(md=12, lg=2, className="m-3", children=[
@@ -43,6 +87,29 @@ def get_oauth_config_layout(redirect_url):
                 ),
             ])
         ])]))
+
+# Generate the OAuth URL and display it to the user, so they can complete the login flow manually.
+@dash_app.callback(
+    Output("manual-oauth-link", "children"),
+    Input("generate-manual-oauth", "n_clicks"),
+    State("psa-manual-app", "value"),
+    State("psa-manual-email", "value"),
+    State("psa-manual-password", "value"),
+    State("psa-manual-countrycode", "value"))
+def generate_manual_oauth_url(n_clicks, app_name, email, password, countrycode):
+    ctx = callback_context
+    if ctx.triggered:
+        try:
+            config_views.INITIAL_SETUP = InitialSetup(app_name, email, password, countrycode)
+            auth_url = config_views.INITIAL_SETUP.psacc.manager.generate_redirect_url()
+            return dbc.Alert([
+                html.P("Open the following login URL and then paste the code returned by the redirect."),
+                html.A("Open OAuth login", href=auth_url, target="_blank"),
+            ], color="info")
+        except Exception as e:
+            logger.exception("generate_manual_oauth_url:")
+            return dbc.Alert(str(e), color="danger")
+    raise PreventUpdate()
 
 
 @dash_app.callback(

--- a/psa_car_controller/web/view/config_views.py
+++ b/psa_car_controller/web/view/config_views.py
@@ -6,7 +6,6 @@ from dash.exceptions import PreventUpdate
 
 from psa_car_controller.psa.otp.otp import new_otp_session
 from psa_car_controller.psa.setup.headless_oauth import HeadlessOAuthError, get_oauth_code_headless
-from psa_car_controller.web.view.config_oauth import get_oauth_config_layout
 from psa_car_controller.psacc.application.car_controller import PSACarController
 from psa_car_controller.psa.setup.app_decoder import InitialSetup
 from psa_car_controller.common.mylogger import LOG_FILE
@@ -119,6 +118,7 @@ def log_layout():
 
 
 def config_layout(activeTabs="log"):
+    from psa_car_controller.web.view.config_oauth import setup_config_manual_layout
     return dbc.Tabs(active_tab=activeTabs, children=[
         dbc.Tab([log_layout()], label="Log", tab_id="log"),
         dbc.Tab([setup_config_layout], label="User config", tab_id="login"),

--- a/psa_car_controller/web/view/config_views.py
+++ b/psa_car_controller/web/view/config_views.py
@@ -6,6 +6,7 @@ from dash.exceptions import PreventUpdate
 
 from psa_car_controller.psa.otp.otp import new_otp_session
 from psa_car_controller.psa.setup.headless_oauth import HeadlessOAuthError, get_oauth_code_headless
+from psa_car_controller.web.view.config_oauth import get_oauth_config_layout
 from psa_car_controller.psacc.application.car_controller import PSACarController
 from psa_car_controller.psa.setup.app_decoder import InitialSetup
 from psa_car_controller.common.mylogger import LOG_FILE
@@ -121,7 +122,10 @@ def config_layout(activeTabs="log"):
     return dbc.Tabs(active_tab=activeTabs, children=[
         dbc.Tab([log_layout()], label="Log", tab_id="log"),
         dbc.Tab([setup_config_layout], label="User config", tab_id="login"),
-        dbc.Tab([config_otp_layout], label="OTP config", tab_id="otp")])
+        dbc.Tab([setup_config_manual_layout()], label = "Manual config", tab_id="manual"),
+        dbc.Tab([config_otp_layout], label="OTP config", tab_id="otp")
+        ]
+    )
 
 
 @dash_app.callback(


### PR DESCRIPTION
Successfully ran Prospector without comment on my changes.

I've added an additional config tab called 'manual login' which is functionally similar to the fallback method, but is permanently available. This adds value to the project as it ensures an authentication method is always available.