### PR TITLE
feat: add model C5 Aircross 1.5 BlueHDi 130

### DIFF
--- a/psa_car_controller/psacc/resources/car_models.yml
+++ b/psa_car_controller/psacc/resources/car_models.yml
@@ -681,6 +681,14 @@
   reg: VR7ARHNSSP 
   max_elec_consumption: 70
   max_fuel_consumption: 30
+- !CarModel
+  name: C5 Aircross 1.5 BlueHDi 130
+  battery_power: 0
+  fuel_capacity: 53
+  abrp_name:
+  reg: VR7ACYHZ7T
+  max_elec_consumption: 0
+  max_fuel_consumption: 30
 - !ElecModel
   name: Combo-e Cargo XL
   battery_power: 50


### PR DESCRIPTION
## Summary

- add the Citroën C5 Aircross 1.5 BlueHDi 130 model
- set the diesel vehicle to 0 kWh battery capacity and 53 L fuel capacity
- add its first 10 VIN characters for model matching

Closes #1267

## Validation

- loaded `car_models.yml` through `CarModelRepository`
- verified the new VIN prefix resolves to the expected model and capacities
- verified all 144 VIN prefixes are unique and non-overlapping
- `git diff --check`
