### PR TITLE
Handle position.level NULL in get_elec_consumption.

### DIFF
--- a/psa_car_controller/psacc/application/trip_parser.py
+++ b/psa_car_controller/psacc/application/trip_parser.py
@@ -29,6 +29,8 @@ class TripParser:
 
     @staticmethod
     def get_elec_consumption(start, end):
+        if start[LEVEL] is None or end[LEVEL] is None:
+            return [0, 0]
         return [start[LEVEL] - end[LEVEL], 0]
 
     @staticmethod


### PR DESCRIPTION
For several months now, my PSA Car Controller has been displaying the following log messages, and on the Summary / Trips / Charge and Maps tabs, the only message displayed was "No data to show, there is probably no trips recorded yet" in a red box.
```
psacc-1  | 2026-08-13 07:48:25,273 :: INFO :: update_trips
psacc-1  | 2026-08-13 07:48:25,422 :: ERROR :: Failed to get trips, there is probably not enough data yet:
psacc-1  | Traceback (most recent call last):
psacc-1  |   File "/usr/local/lib/python3.11/dist-packages/psa_car_controller/web/view/views.py", line 387, in <module>
psacc-1  |     update_trips()
psacc-1  |   File "/usr/local/lib/python3.11/dist-packages/psa_car_controller/web/view/views.py", line 203, in update_trips
psacc-1  |     trips_by_vin = Trips.get_trips(Cars([car]))
psacc-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psacc-1  |   File "/usr/local/lib/python3.11/dist-packages/psa_car_controller/psacc/repository/trips.py", line 98, in get_trips
psacc-1  |     if trip_parser.is_refuel(end, next_point, distance) or \
psacc-1  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psacc-1  |   File "/usr/local/lib/python3.11/dist-packages/psa_car_controller/psacc/application/trip_parser.py", line 63, in __is_recharging
psacc-1  |     decharge = self.get_level_consumption(start, end)[0]
psacc-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psacc-1  |   File "/usr/local/lib/python3.11/dist-packages/psa_car_controller/psacc/application/trip_parser.py", line 32, in get_elec_consumption
psacc-1  |     return [start[LEVEL] - end[LEVEL], 0]
psacc-1  |             ~~~~~~~~~~~~~^~~~~~~~~~~~
psacc-1  | TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'

```

A database query on the ‘position’ table returned a record in which the ‘level’ field is NULL.

This situation is already handled in `trip_parser.py` for hybrid models (`get_hybrid_consumption`); I have now added a similar check to `get_elec_consumption`.

With this change, the tabs mentioned above are now displayed normally for me again.